### PR TITLE
possible fix to double search bug

### DIFF
--- a/web/frontend/src/app/component/general-search/general-search.component.ts
+++ b/web/frontend/src/app/component/general-search/general-search.component.ts
@@ -358,6 +358,7 @@ export class GeneralSearchComponent implements OnInit,
   // Handler for clicking the "Search" button
   onPerformSearch() {
     console.log('onPerformSearch', this.termautosearch);
+    this.avoidLazyLoading = true; // don't see any reason for lazy loading here
     this.resetTable();
     this.performSearch(this.termautosearch);
   }


### PR DESCRIPTION
The double search seems to have come from the search button performing both its normal search and a lazy load search. I don't see any reason for the search button to perform a lazy load search, so I told it not to in this commit. The search button now only searches once, and in my testing, I didn't find anything in the workflow that broke, so as far as I can tell this should do it.