### PR TITLE
RDFBROWSER-67: Change control to not use a filter

### DIFF
--- a/web/frontend/src/app/component/general-search/general-search.component.html
+++ b/web/frontend/src/app/component/general-search/general-search.component.html
@@ -26,7 +26,7 @@
             <div class="ui-inputgroup" style="padding-top: 6px;float:left;">
               <p-multiSelect autoWidth="false" [showToggleAll]="true" dropdownIcon="pi pi-caret-down"
                 [options]="sourcesAll" [(ngModel)]="selectedSource" name="sourceSearch" defaultLabel="Source"
-                (onChange)="onChangeSource($event)" [displaySelectedLabel]="false">
+                [filter]="true" (onChange)="onChangeSource($event)" [displaySelectedLabel]="false">
                 <ng-template let-source let-i="index" pTemplate="item">
                   <span style="vertical-align: bottom;">{{source.label}}</span>
                 </ng-template>
@@ -105,9 +105,10 @@
 
               <p-toggleButton [(ngModel)]="columnMore" (onChange)="setDefaultColumns()" onLabel="Show Less"
                 offLabel="Show more" onIcon="pi pi-times" offIcon="pi pi-check"></p-toggleButton>
-              <p-multiSelect dropdownIcon="pi pi-caret-down" [options]="multiSelectCols" [(ngModel)]="selectedColumns"
-                (onChange)="setColumns()" selectedItemsLabel=" {0} columns selected" [style]="{minWidth: '200px'}"
-                defaultLabel="Choose Columns"></p-multiSelect>
+              <p-multiSelect [showToggleAll]="false" dropdownIcon="pi pi-caret-down" [options]="multiSelectCols"
+                [(ngModel)]="selectedColumns" name="columnNames" defaultLabel="Search Result Details" [filter]="false"
+                (onChange)="setColumns()" [displaySelectedLabel]="false" [style]="{minWidth: '200px'}">
+              </p-multiSelect>
 
             </div>
           </p-toolbar>

--- a/web/frontend/src/app/component/general-search/general-search.component.ts
+++ b/web/frontend/src/app/component/general-search/general-search.component.ts
@@ -342,7 +342,7 @@ export class GeneralSearchComponent implements OnInit,
 
   // Handle a change of the source - save in session storage and re-search
   onChangeSource(event) {
-    console.log('onChangeSource');
+    console.log('onChangeSource', event, this.selectedSource);
     sessionStorage.setItem('source', JSON.stringify(this.selectedSource));
     this.performSearch(this.termautosearch);
   }


### PR DESCRIPTION
Address the weirdness in filter behavior by removing it.  It's not necessary because there are only 4 options in the list.  I removed the "select all" control as well - at most you have to click 3 times.