### PR TITLE
Rdfbrowser88

### DIFF
--- a/web/frontend/src/app/component/evs-header/evs-header.component.html
+++ b/web/frontend/src/app/component/evs-header/evs-header.component.html
@@ -47,17 +47,6 @@
   <div class="collapse navbar-collapse" id="navbarCollapse">
     <ul class="navbar-nav ml-auto">
       <li class="nav-item">
-        <a class="nav-link" routerLink="valuesets" title="Display Value Sets">Value Sets</a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" routerLink="mappings" title="Display Mappings">Mappings</a>
-      </li>
-      <!--
-      <li class="nav-item">
-        <a class="nav-link" routerLink="conceptlist">Concept List</a>
-      </li>
-      -->
-      <li class="nav-item">
         <a class="nav-link" routerLink="hierarchy/C12913" title="Display Concept Hierarchy">Hierarchy</a>
       </li>
       <li class="nav-item dropdown">
@@ -75,7 +64,7 @@
       <li class="nav-item">
         <a class="nav-link" routerLink="overview" title="Help">Help</a>
       </li>
-      <!-- 
+      <!--
       <li class="nav-item dropdown">
         <a class="nav-link dropdown-toggle" href="#" id="helpMenu" data-toggle="dropdown" aria-haspopup="true"
           aria-expanded="false" title="Display Help Menu">Help</a>

--- a/web/frontend/src/app/component/evs-header/evs-header.component.html
+++ b/web/frontend/src/app/component/evs-header/evs-header.component.html
@@ -46,6 +46,17 @@
   </button>
   <div class="collapse navbar-collapse" id="navbarCollapse">
     <ul class="navbar-nav ml-auto">
+      <!--
+      <li class="nav-item">
+        <a class="nav-link" routerLink="valuesets" title="Display Value Sets">Value Sets</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" routerLink="mappings" title="Display Mappings">Mappings</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" routerLink="conceptlist">Concept List</a>
+      </li>
+      -->
       <li class="nav-item">
         <a class="nav-link" routerLink="hierarchy/C12913" title="Display Concept Hierarchy">Hierarchy</a>
       </li>

--- a/web/frontend/src/app/component/welcome/welcome.component.html
+++ b/web/frontend/src/app/component/welcome/welcome.component.html
@@ -82,6 +82,13 @@
             the Federal Medication Terminologies (FMT), and the National Council for Prescription Drug Programs (NCPDP).
           </p>
 
+          <!--
+          <p>
+            Source Home Page:
+            <a href="https://ncit.nci.nih.gov" target="_blank">https://ncit.nci.nih.gov</a>
+          </p>
+          -->
+
           <p>
             Download:
             <a href="http://evs.nci.nih.gov/ftp1/NCI_Thesaurus"
@@ -117,6 +124,34 @@
                   <a href="http://evs.nci.nih.gov/" target="_blank" alt="EVS">NCI Enterprise Vocabulary Services</a>:
                   Terminology resources and services for NCI and the biomedical community.
                 </td>
+              </tr>
+              <!--
+              <tr valign="top">
+                <td>
+                  <a href="https://ncim.nci.nih.gov/ncimbrowser" target="_blank" alt="NCIm">
+                    <img src="assets/images/NCImTile.png" width="77" height="38px" alt="NCIm" border="0" />
+                  </a>
+                </td>
+                <td width="3px;"></td>
+                <td class="textbody" valign="top">
+                  <a href="https://ncim.nci.nih.gov/ncimbrowser" target="_blank" alt="NCIm">NCI Metathesaurus</a>:
+                  Comprehensive database of 6,700,000 terms from over 85 terminologies.
+                </td>
+
+              </tr>
+              <tr valign="top">
+                <td>
+                  <a href="https://ncit.nci.nih.gov/ncitbrowser/" alt="NCI Term Browser">
+                    <img src="assets/images/EVSTermsBrowserTile.png" width="77" height="38px" alt="NCI Term Browser"
+                      border="0" />
+                  </a>
+                </td>
+                <td width="3px;"></td>
+                <td class="textbody" valign="top">
+                  <a href="https://ncit.nci.nih.gov/ncitbrowser/" alt="NCI Term Browser">NCI Term Browser</a>:
+                  NCI and other terminologies in an integrated environment.
+                </td>
+              -->
               </tr>
               <tr valign="top">
                 <td>

--- a/web/frontend/src/app/component/welcome/welcome.component.html
+++ b/web/frontend/src/app/component/welcome/welcome.component.html
@@ -83,11 +83,6 @@
           </p>
 
           <p>
-            Source Home Page:
-            <a href="https://ncit.nci.nih.gov" target="_blank">https://ncit.nci.nih.gov</a>
-          </p>
-
-          <p>
             Download:
             <a href="http://evs.nci.nih.gov/ftp1/NCI_Thesaurus"
               target="_blank">http://evs.nci.nih.gov/ftp1/NCI_Thesaurus</a>
@@ -122,33 +117,6 @@
                   <a href="http://evs.nci.nih.gov/" target="_blank" alt="EVS">NCI Enterprise Vocabulary Services</a>:
                   Terminology resources and services for NCI and the biomedical community.
                 </td>
-              </tr>
-              <tr valign="top">
-                <td>
-                  <a href="https://ncim.nci.nih.gov/ncimbrowser" target="_blank" alt="NCIm">
-                    <img src="assets/images/NCImTile.png" width="77" height="38px" alt="NCIm" border="0" />
-                  </a>
-                </td>
-                <td width="3px;"></td>
-                <td class="textbody" valign="top">
-                  <a href="https://ncim.nci.nih.gov/ncimbrowser" target="_blank" alt="NCIm">NCI Metathesaurus</a>:
-                  Comprehensive database of 6,700,000 terms from over 85 terminologies.
-                </td>
-
-              </tr>
-              <tr valign="top">
-                <td>
-                  <a href="https://ncit.nci.nih.gov/ncitbrowser/" alt="NCI Term Browser">
-                    <img src="assets/images/EVSTermsBrowserTile.png" width="77" height="38px" alt="NCI Term Browser"
-                      border="0" />
-                  </a>
-                </td>
-                <td width="3px;"></td>
-                <td class="textbody" valign="top">
-                  <a href="https://ncit.nci.nih.gov/ncitbrowser/" alt="NCI Term Browser">NCI Term Browser</a>:
-                  NCI and other terminologies in an integrated environment.
-                </td>
-
               </tr>
               <tr valign="top">
                 <td>


### PR DESCRIPTION
1. Remove the Value Sets and Mappings links from the banner.
2. Remove "Source Home Page: https://ncit.nci.nih.gov" from Welcome page text.
3. Remove NCI Metathesaurus and NCI Term Browser links from the Welcome page

Leaves NCIm links from concept details in place as per previous discussion