### PR TITLE
RDFBROWSER-146: subsets:  '{,[' characters causing search errors

### DIFF
--- a/web/frontend/src/app/service/concept-detail.service.ts
+++ b/web/frontend/src/app/service/concept-detail.service.ts
@@ -20,7 +20,7 @@ export class ConceptDetailService {
   // Get concept with summary includes
   getConceptSummary(conceptCode: string, include: string): Observable<any> {
     console.log(this.configService.getTerminology().terminology)
-    return this.http.get('/api/v1/concept/' + this.configService.getTerminology().terminology + '/' + conceptCode + '?include=' + include,
+    return this.http.get(encodeURI('/api/v1/concept/' + this.configService.getTerminology().terminology + '/' + conceptCode + '?include=' + include),
       {
         responseType: 'json',
         params: {
@@ -36,7 +36,7 @@ export class ConceptDetailService {
 
   // Get properties
   getProperties(): Observable<any> {
-    return this.http.get('/api/v1/metadata/' + this.cookieService.get('term') + '/properties',
+    return this.http.get(encodeURI('/api/v1/metadata/' + this.cookieService.get('term') + '/properties'),
       {
         responseType: 'json',
       }
@@ -50,7 +50,7 @@ export class ConceptDetailService {
 
   // Get the concept relationships (roles, associations, inverseRoles, inverseAssociations, and maps?)
   getRelationships(conceptCode: string) {
-    return this.http.get('/api/v1/concept/' + this.cookieService.get('term') + '/' + conceptCode + '?include=parents,children,roles,associations,inverseRoles,inverseAssociations,disjointWith',
+    return this.http.get(encodeURI('/api/v1/concept/' + this.cookieService.get('term') + '/' + conceptCode + '?include=parents,children,roles,associations,inverseRoles,inverseAssociations,disjointWith'),
       {
         responseType: 'json',
         params: {
@@ -68,49 +68,49 @@ export class ConceptDetailService {
   // Get hierarchy data (either paths from root, or children)
   getHierarchyData(code: string) {
     const url = '/api/v1/concept/' + this.cookieService.get('term') + '/' + code + '/subtree';
-    return this.http.get(url)
+    return this.http.get(encodeURI(url))
       .toPromise()
       .then(res => <TreeNode[]>res);
   }
 
   // Get hierarchy data for children of specified code.
   getHierarchyChildData(code: string) {
-    const url = '/api/v1/concept/' + this.cookieService.get('term') + '/' + code + '/subtree/children';
-    return this.http.get(url)
+    const url = encodeURI('/api/v1/concept/' + this.cookieService.get('term') + '/' + code + '/subtree/children');
+    return this.http.get(encodeURI(url))
       .toPromise()
       .then(res => <TreeNode[]>res);
   }
 
   // Get Value Set Top Level
   getSubsetTopLevel() {
-    const url = '/api/v1/metadata/' + this.cookieService.get('term') + '/subsets?include=minimal'
-    return this.http.get(url)
+    const url = encodeURI('/api/v1/metadata/' + this.cookieService.get('term') + '/subsets?include=minimal');
+    return this.http.get(encodeURI(url))
       .toPromise()
       .then(res => <TreeNode[]>res);
   }
 
   // Get Value Set Top Level
   getSubsetDetails(code: string) {
-    const url = '/api/v1/concept/' + this.cookieService.get('term') + '/subsetMembers/' + code;
-    return this.http.get(url)
+    const url = encodeURI('/api/v1/concept/' + this.cookieService.get('term') + '/subsetMembers/' + code);
+    return this.http.get(encodeURI(url))
       .toPromise()
       .then(res => <Array<Concept>[]>res);
   }
 
   getSubsetFullDetails(code: string, fromRecord = 0, pageSize = 10, searchTerm = "") {
-    var url = '/api/v1/concept/' + this.cookieService.get('term') + '/search?include=full&subset=' + code + "&fromRecord=" + fromRecord + "&pageSize=" + pageSize;
+    var url = encodeURI('/api/v1/concept/' + this.cookieService.get('term') + '/search?include=full&subset=' + code + "&fromRecord=" + fromRecord + "&pageSize=" + pageSize);
     if (searchTerm != "")
       url += "&term=" + searchTerm;
     console.log(url);
-    return this.http.get(url)
+    return this.http.get(encodeURI(url))
       .toPromise()
       .then(res => <Array<Concept>[]>res);
   }
 
   getSubsetInfo(code: string, include: string) {
-    var url = '/api/v1/metadata/' + this.cookieService.get('term') + '/subset/' + code + '?include=' + include;
+    var url = encodeURI('/api/v1/metadata/' + this.cookieService.get('term') + '/subset/' + code + '?include=' + include);
     console.log(url)
-    return this.http.get(url)
+    return this.http.get(encodeURI(url))
       .toPromise()
       .then(res => <Array<Concept>[]>res);
   }

--- a/web/frontend/src/app/service/configuration.service.ts
+++ b/web/frontend/src/app/service/configuration.service.ts
@@ -78,7 +78,7 @@ export class ConfigurationService {
 
   // Load associations
   getAssociations(terminology: string): Observable<any> {
-    return this.http.get('/api/v1/metadata/' + terminology + '/associations?include=summary',
+    return this.http.get(encodeURI('/api/v1/metadata/' + terminology + '/associations?include=summary'),
       {
         responseType: 'json',
       }
@@ -92,7 +92,7 @@ export class ConfigurationService {
 
   // Load roles
   getRoles(terminology: string): Observable<any> {
-    return this.http.get('/api/v1/metadata/' + terminology + '/roles?include=summary',
+    return this.http.get(encodeURI('/api/v1/metadata/' + terminology + '/roles?include=summary'),
       {
         responseType: 'json',
       }
@@ -106,7 +106,7 @@ export class ConfigurationService {
 
   // Load properties
   getProperties(terminology: string): Observable<any> {
-    return this.http.get('/api/v1/metadata/' + terminology + '/properties?include=summary',
+    return this.http.get(encodeURI('/api/v1/metadata/' + terminology + '/properties?include=summary'),
       {
         responseType: 'json',
       }
@@ -120,7 +120,7 @@ export class ConfigurationService {
 
   // Load qualifiers
   getQualifiers(terminology: string): Observable<any> {
-    return this.http.get('/api/v1/metadata/' + terminology + '/qualifiers?include=summary',
+    return this.http.get(encodeURI('/api/v1/metadata/' + terminology + '/qualifiers?include=summary'),
       {
         responseType: 'json',
       }
@@ -134,7 +134,7 @@ export class ConfigurationService {
 
   // Load term types
   getTermTypes(terminology: string): Observable<any> {
-    return this.http.get('/api/v1/metadata/' + terminology + '/termTypes',
+    return this.http.get(encodeURI('/api/v1/metadata/' + terminology + '/termTypes'),
       {
         responseType: 'json',
       }
@@ -148,7 +148,7 @@ export class ConfigurationService {
 
   // Load synonym sources
   getSynonymSources(terminology: string): Observable<any> {
-    return this.http.get('/api/v1/metadata/' + terminology + '/synonymSources',
+    return this.http.get(encodeURI('/api/v1/metadata/' + terminology + '/synonymSources'),
       {
         responseType: 'json',
       }
@@ -162,7 +162,7 @@ export class ConfigurationService {
 
   // Load synonym sources
   getSynonymTypes(terminology: string): Observable<any> {
-    return this.http.get('/api/v1/metadata/' + terminology + '/synonymTypes',
+    return this.http.get(encodeURI('/api/v1/metadata/' + terminology + '/synonymTypes'),
       {
         responseType: 'json',
       }
@@ -175,7 +175,7 @@ export class ConfigurationService {
   }
 
   getDefinitionSources(terminology: string): Observable<any> {
-    return this.http.get('/api/v1/metadata/' + terminology + '/definitionSources',
+    return this.http.get(encodeURI('/api/v1/metadata/' + terminology + '/definitionSources'),
       {
         responseType: 'json',
       }
@@ -188,7 +188,7 @@ export class ConfigurationService {
   }
 
   getDefinitionTypes(terminology: string): Observable<any> {
-    return this.http.get('/api/v1/metadata/' + terminology + '/definitionTypes',
+    return this.http.get(encodeURI('/api/v1/metadata/' + terminology + '/definitionTypes'),
       {
         responseType: 'json',
       }

--- a/web/frontend/src/app/service/search-term.service.ts
+++ b/web/frontend/src/app/service/search-term.service.ts
@@ -88,7 +88,7 @@ export class SearchTermService {
     // }
 
     // Perform the HTTP call
-    return this.http.get(url,
+    return this.http.get(encodeURI(url),
       {
         responseType: 'json',
         params: param


### PR DESCRIPTION
solves https://tracker.nci.nih.gov/browse/RDFBROWSER-146

I originally thought I'd have to mess with config files for the server to explicitly allow these characters but turns out you can just encode them and it all works out.

