### PR TITLE
fix mapping search export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,11 @@ __pycache__
 WEB-INF/*
 node_modules
 log
+web/bin/main/*
 
 # IDE - IntelliJ
 .idea/
 
 # System Files
 .DS_Store
+

--- a/web/frontend/src/app/component/mapping-details/mapping-details.component.ts
+++ b/web/frontend/src/app/component/mapping-details/mapping-details.component.ts
@@ -198,7 +198,7 @@ export class MappingDetailsComponent implements OnInit {
 
   async exportMapping(self = this) {
     this.loaderService.showLoader();
-    const pages = Math.ceil(this.fullTotal / this.MAX_PAGE);
+    const pages = Math.ceil(self.fullTotal / self.MAX_PAGE);
     let mappingText = '';
 
     for (let i = 0; i < pages; i++) {

--- a/web/frontend/src/app/component/mapping-details/mapping-details.component.ts
+++ b/web/frontend/src/app/component/mapping-details/mapping-details.component.ts
@@ -198,12 +198,12 @@ export class MappingDetailsComponent implements OnInit {
 
   async exportMapping(self = this) {
     this.loaderService.showLoader();
-    const pages = Math.ceil(self.fullTotal / self.MAX_PAGE);
+    const pages = Math.ceil(self.total / self.MAX_PAGE);
     let mappingText = '';
 
     for (let i = 0; i < pages; i++) {
       await this.configService
-        .getMapsetMappings(self.mapsetCode, Math.min(self.MAX_PAGE, self.fullTotal - i * self.MAX_PAGE), i * self.MAX_PAGE, self.termAutoSearch)
+        .getMapsetMappings(self.mapsetCode, Math.min(self.MAX_PAGE, self.total - i * self.MAX_PAGE), i * self.MAX_PAGE, self.termAutoSearch)
         .toPromise()
         .then((result) => {
           result['maps'].forEach((c) => {

--- a/web/frontend/src/app/component/mapping-details/mapping-details.component.ts
+++ b/web/frontend/src/app/component/mapping-details/mapping-details.component.ts
@@ -203,7 +203,7 @@ export class MappingDetailsComponent implements OnInit {
 
     for (let i = 0; i < pages; i++) {
       await this.configService
-        .getMapsetMappings(self.mapsetCode, Math.min(self.MAX_PAGE, self.fullTotal - i * self.MAX_PAGE), i * self.MAX_PAGE)
+        .getMapsetMappings(self.mapsetCode, Math.min(self.MAX_PAGE, self.fullTotal - i * self.MAX_PAGE), i * self.MAX_PAGE, self.termAutoSearch)
         .toPromise()
         .then((result) => {
           result['maps'].forEach((c) => {


### PR DESCRIPTION
Fixes the mapping export to only export search results when a search has been performed. Also removes a duplicate function that was causing compile errors.

JIRA: https://tracker.nci.nih.gov/browse/RDFBROWSER-487