### PR TITLE
Ams/rdfbrowser 476 npo export definitions clean

### DIFF
--- a/frontend/src/app/component/general-search/general-search.component.ts
+++ b/frontend/src/app/component/general-search/general-search.component.ts
@@ -602,12 +602,13 @@ export class GeneralSearchComponent implements OnInit, OnDestroy, AfterViewInit 
 
           //if definition is "complex" (contains <>), remove <>s
           while (def.definition.includes('<')){
+            
             if (def.definition.indexOf('<') <= 1) {
               def.definition = def.definition.substring(def.definition.indexOf('>')+1);
             }
-            // else if (def.defintion.) {
-            //   def.definition = def.definition.substring(0, def.definition.indexOf('<')) + def.definition.substring(def.definition.indexOf('>'));
-            // }
+            else if (def.definition.match(/</g).length > 2) {
+              def.definition = def.definition.substring(0, def.definition.indexOf('<')) + def.definition.substring(def.definition.indexOf('>')+1);
+            }
             else {
               def.definition = def.definition.substring(0, def.definition.indexOf('<'));
             }

--- a/frontend/src/app/component/general-search/general-search.component.ts
+++ b/frontend/src/app/component/general-search/general-search.component.ts
@@ -599,6 +599,20 @@ export class GeneralSearchComponent implements OnInit, OnDestroy, AfterViewInit 
       if (concept.definitions != undefined && concept.definitions.length > 0) {
         definitionString += '"';
         for (let def of concept.definitions) {
+
+          //if definition is "complex" (contains <>), remove <>s
+          while (def.definition.includes('<')){
+            if (def.definition.indexOf('<') <= 1) {
+              def.definition = def.definition.substring(def.definition.indexOf('>')+1);
+            }
+            // else if (def.defintion.) {
+            //   def.definition = def.definition.substring(0, def.definition.indexOf('<')) + def.definition.substring(def.definition.indexOf('>'));
+            // }
+            else {
+              def.definition = def.definition.substring(0, def.definition.indexOf('<'));
+            }
+          }
+
           definitionString += (def.source ? def.source + ': ' : '') + def.definition.replace(/"/g, '""') + '\n';
         }
         // remove last newline


### PR DESCRIPTION
Changed general search export formatting to account for NPO complex definitions. Gets just text values instead of including all <> tag formatting also.