### PR TITLE
No results found fixed when searching for subsets and concepts within mappings details.

### DIFF
--- a/frontend/src/app/component/mapping-details/mapping-details.component.css
+++ b/frontend/src/app/component/mapping-details/mapping-details.component.css
@@ -2,3 +2,7 @@
   margin-left: 2px;
   margin-right: 2px;
 }
+
+.table-responsive {
+  overflow-x: visible;
+}

--- a/frontend/src/app/component/mapping-details/mapping-details.component.html
+++ b/frontend/src/app/component/mapping-details/mapping-details.component.html
@@ -34,6 +34,7 @@
               (onClear)="ngOnInit()"
               placeholder="Enter at least 3 letters of a term."
               [minLength]="3"
+              [showEmptyMessage]="false"
             >
             </p-autoComplete>
           </div>
@@ -62,10 +63,12 @@
           </div>
         </div>
       </div>
-      <div *ngIf="!mapsetMappings && termAutoSearch">
-        <i class="fa fa-info-circle"></i>&nbsp;&nbsp;No mappings found that matched the above search.
-      </div>
-      <div *ngIf="mapsetMappings" class="table-responsive">
+      <p-toolbar *ngIf="mapsetMappings?.length == 0 && termAutoSearch">
+        <div>
+          <i class="fa fa-info-circle"></i>&nbsp;&nbsp;No mappings found that matched the above search.
+        </div>
+      </p-toolbar>
+      <div *ngIf="mapsetMappings?.length > 0" class="table-responsive">
         <p-table
           *ngIf="mapsetMappings"
           #mappings

--- a/frontend/src/app/component/subsets/subsets.component.html
+++ b/frontend/src/app/component/subsets/subsets.component.html
@@ -22,11 +22,19 @@
       <div class="row search-row">
         <div class="col-sm-4 search-bar">
           <div>
-            <p-autoComplete id="subsetSearch" [(ngModel)]="enteredSearchText"            
-        [inputStyle]="{'width':'100%'}" [delay]="800" [suggestions]="subsetSuggestions"
-        (completeMethod)="performSubsetSearch()" placeholder="{{placeholderText}}" [minLength]="3"
-        [disabled]="searchDisabled">
-      </p-autoComplete>
+            <p-autoComplete
+              id="subsetSearch" 
+              [(ngModel)]="enteredSearchText" 
+              [inputStyle]="{'width':'100%'}" 
+              [delay]="800" 
+              [suggestions]="subsetSuggestions"
+              (completeMethod)="performSubsetSearch()" 
+              placeholder="{{placeholderText}}" 
+              [minLength]="3"
+              [disabled]="searchDisabled" 
+              [showEmptyMessage]="false"
+            >
+            </p-autoComplete>
           </div>
 
         </div>


### PR DESCRIPTION
Changed mapping details and subset search pages so that "No results found" did not pop up unnecessarily.