### PR TITLE
Add hierarchical AGENTS context files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# Repository Context
+
+## Global Architecture
+
+EVS Explore is a terminology browser with two primary modules:
+
+- `frontend/`: Angular application for search, concept display, hierarchy browsing, subsets, mappings, documentation, and term suggestion workflows.
+- `web/`: Spring Boot Java 17 web module packaged as a WAR. It serves the built Angular app and proxies `/api/v1/**` requests to EVSRESTAPI.
+
+Production-style builds copy Angular output into `web/src/main/resources/static`, where the Java web module serves it as static content.
+
+## Build/Test Commands
+
+- `make build`: build the Java web module from `web/` without tests.
+- `make frontend`: build the Angular app and copy output into `web/src/main/resources/static`.
+- `make test`: run frontend Jest tests through `frontend`.
+- `cd web && ./gradlew test`: run Java tests.
+- `cd frontend && npm start`: run Angular locally against `proxy.config.json`.
+- `cd frontend && npm run start:dev`: run Angular locally against the NCI dev EVSRESTAPI proxy.
+
+## Global Coding Standards
+
+- Keep generated or copied build output separate from source changes unless the task explicitly requires updating it.
+- Prefer existing framework patterns already used in the target module.
+- Keep cross-module details at the nearest common parent; put implementation details in the directory that owns them.
+- When a child directory has its own `AGENTS.md`, parent files should describe that child's scope and link to it instead of repeating its rules.
+- Do not add new dependencies or build tools without a clear module-level reason.
+
+## Context Map
+
+- [frontend/AGENTS.md](frontend/AGENTS.md): Angular module build, source layout, and frontend context map.
+- [frontend/src/AGENTS.md](frontend/src/AGENTS.md): browser entry points, global styles, assets, and environment files.
+- [frontend/src/app/AGENTS.md](frontend/src/app/AGENTS.md): Angular shell, routing, module registration, and app-level testing conventions.
+- [frontend/src/app/component/AGENTS.md](frontend/src/app/component/AGENTS.md): shared component conventions and feature-component map.
+- [frontend/src/app/service/AGENTS.md](frontend/src/app/service/AGENTS.md): API, configuration, loading, notification, and error service patterns.
+- [frontend/src/app/model/AGENTS.md](frontend/src/app/model/AGENTS.md): frontend model and DTO wrapper patterns.
+- [frontend/src/app/directive/AGENTS.md](frontend/src/app/directive/AGENTS.md): Angular directive context.
+- [frontend/src/environments/AGENTS.md](frontend/src/environments/AGENTS.md): Angular environment replacements and runtime constants.
+- [frontend/src/assets/AGENTS.md](frontend/src/assets/AGENTS.md): source assets copied by Angular builds.
+- [frontend/cypress/AGENTS.md](frontend/cypress/AGENTS.md): Cypress e2e context.
+- [web/AGENTS.md](web/AGENTS.md): Java web module, packaging, resources, and backend context map.
+- [web/src/main/java/gov/nih/nci/evsexplore/web/AGENTS.md](web/src/main/java/gov/nih/nci/evsexplore/web/AGENTS.md): Java application package context.
+- [web/src/test/java/gov/nih/nci/evsexplore/web/AGENTS.md](web/src/test/java/gov/nih/nci/evsexplore/web/AGENTS.md): Java test package context.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,0 +1,34 @@
+# Frontend Module Context
+
+## Scope
+
+This module owns the Angular EVS Explore user interface, local Angular development server setup, frontend unit/e2e test configuration, and production build output copied into the Java web module.
+
+## Angular Build and Test Commands
+
+- `npm start`: serve locally through `proxy.config.json`.
+- `npm run start:dev`: serve locally through `proxy.dev.config.json`.
+- `npm run build`: standard Angular build.
+- `npm run build:prod`: production build with `/evsexplore/` base href.
+- `npm run test`: Jest unit tests.
+- `npm run cypress:open` or `npm run cypress:run`: Cypress e2e workflows.
+- `./gradlew build`: runs the Gradle Node build and copies `dist` into `../web/src/main/resources/static`.
+
+## Frontend Architecture
+
+The frontend is an Angular application using PrimeNG, ng-bootstrap, Angular forms, Angular routing, Jest, and Cypress. Application behavior is organized around components, services, models, directives, environment files, and source assets.
+
+## Development Proxy Targets
+
+Local API proxying is configured outside source code:
+
+- `proxy.config.json`: `/api/v1/**` to local EVSRESTAPI on port 8082.
+- `proxy.dev.config.json`: `/api/v1/**` to the NCI dev EVSRESTAPI endpoint.
+
+## Context Map
+
+- [src/AGENTS.md](src/AGENTS.md): browser entry points, styles, assets, and environments.
+- [src/app/AGENTS.md](src/app/AGENTS.md): Angular app shell, routing, module registration, and child app contexts.
+- [src/environments/AGENTS.md](src/environments/AGENTS.md): development and production environment constants.
+- [src/assets/AGENTS.md](src/assets/AGENTS.md): source images, downloads, and custom PrimeNG CSS.
+- [cypress/AGENTS.md](cypress/AGENTS.md): Cypress e2e setup.

--- a/frontend/cypress/AGENTS.md
+++ b/frontend/cypress/AGENTS.md
@@ -1,0 +1,15 @@
+# Cypress Context
+
+## Scope
+
+This directory owns Cypress e2e configuration, tests, fixtures, and support files for the Angular frontend.
+
+## E2E Configuration
+
+`cypress.config.ts` sets the e2e base URL to the local Angular server. Start the frontend before running Cypress unless the chosen workflow starts it for you.
+
+## Test Entry Points
+
+- `e2e/spec.cy.ts`
+- `support/e2e.ts`
+- `support/commands.ts`

--- a/frontend/src/AGENTS.md
+++ b/frontend/src/AGENTS.md
@@ -1,0 +1,23 @@
+# Frontend Source Context
+
+## Scope
+
+This directory contains browser source files consumed by Angular CLI builds.
+
+## Browser Entry Points
+
+`main.ts` bootstraps `AppModule` and enables production mode based on the active environment file. `index.html` is the browser document entry point. `polyfills.ts` contains Angular browser polyfills.
+
+## Global Styles and Assets
+
+Global CSS is loaded through `angular.json`, including PrimeNG, Font Awesome, Bootstrap, `src/assets/primeng.custom.css`, and `src/styles.css`. Component styles should stay with their component unless they intentionally affect global application styling.
+
+## Runtime Environments
+
+Angular file replacement swaps `src/environments/environment.ts` for `src/environments/environment.prod.ts` in production builds.
+
+## Context Map
+
+- [app/AGENTS.md](app/AGENTS.md): Angular app code.
+- [environments/AGENTS.md](environments/AGENTS.md): environment constants and replacement behavior.
+- [assets/AGENTS.md](assets/AGENTS.md): source assets copied by Angular builds.

--- a/frontend/src/app/AGENTS.md
+++ b/frontend/src/app/AGENTS.md
@@ -1,0 +1,34 @@
+# Angular App Context
+
+## Scope
+
+This directory contains the Angular application shell, routing table, module declarations/providers, feature components, services, models, directives, and unit tests.
+
+## Application Shell
+
+`app.component.ts` owns app-level behavior such as route-change scrolling, Google Analytics page views, terminology license modal handling, and terminology-change subscription cleanup.
+
+## Routing
+
+`app-routing.module.ts` owns the primary route table. Routes map user workflows to components for search, concepts, hierarchy, subsets, mappings, documentation, contact, errors, API info, and term suggestions.
+
+## Dependency Registration
+
+`app.module.ts` registers Angular modules, PrimeNG modules, ng-bootstrap, app components, pipes, services, `APP_INITIALIZER`, global error handling, and the loading interceptor.
+
+## Unit Test Conventions
+
+Component and service specs are colocated with the files they test. Prefer focused TestBed setup and mock services over broad app-module imports when adding new tests.
+
+## Context Map
+
+- [component/AGENTS.md](component/AGENTS.md): component patterns and feature-component map.
+- [service/AGENTS.md](service/AGENTS.md): API, configuration, loader, notification, and error services.
+- [model/AGENTS.md](model/AGENTS.md): EVS DTO-style models and display helpers.
+- [directive/AGENTS.md](directive/AGENTS.md): custom Angular directives.
+
+## Core Files
+
+- `app.component.ts`
+- `app.module.ts`
+- `app-routing.module.ts`

--- a/frontend/src/app/component/AGENTS.md
+++ b/frontend/src/app/component/AGENTS.md
@@ -1,0 +1,31 @@
+# Component Context
+
+## Scope
+
+This directory contains Angular components for EVS Explore workflows and shared UI shell pieces.
+
+## Shared Component Patterns
+
+Most components pair a `.ts` controller with `.html`, `.css`, and `.spec.ts` files. Route-owned components usually read route/query parameters, interact with services, and render PrimeNG or Bootstrap UI structures.
+
+## Routing-Owned Components
+
+The route table in `../app-routing.module.ts` is the source of truth for which components own browser routes. Avoid duplicating route rules in component context files.
+
+## Shell and Utility Components
+
+Simple shell or utility components are covered here unless they receive their own child context. This includes header, footer, loader, notifications, error, contact, API info, page-not-found, source-stats, welcome, concept-history, and concept-relationship components.
+
+## Context Map
+
+- [general-search/AGENTS.md](general-search/AGENTS.md): main terminology search workflow.
+- [concept-display/AGENTS.md](concept-display/AGENTS.md): full concept page and export behavior.
+- [concept-detail/AGENTS.md](concept-detail/AGENTS.md): compact concept detail rendering.
+- [hierarchy-display/AGENTS.md](hierarchy-display/AGENTS.md): full hierarchy browser.
+- [hierarchy-popup/AGENTS.md](hierarchy-popup/AGENTS.md): popup hierarchy browser variant.
+- [subsets/AGENTS.md](subsets/AGENTS.md): subset hierarchy browser.
+- [subset-details/AGENTS.md](subset-details/AGENTS.md): subset member table and export workflow.
+- [mappings/AGENTS.md](mappings/AGENTS.md): mapset listing workflow.
+- [mapping-details/AGENTS.md](mapping-details/AGENTS.md): mapset mapping table workflow.
+- [term-suggestion-form/AGENTS.md](term-suggestion-form/AGENTS.md): dynamic term suggestion form.
+- [documentation/AGENTS.md](documentation/AGENTS.md): metadata documentation pages.

--- a/frontend/src/app/component/concept-detail/AGENTS.md
+++ b/frontend/src/app/component/concept-detail/AGENTS.md
@@ -1,0 +1,23 @@
+# Concept Detail Component Context
+
+## Scope
+
+This component owns compact concept detail rendering used by broader concept workflows.
+
+## User Flow
+
+The component receives or resolves a concept, renders high-value concept fields, and delegates detailed data retrieval to the concept service rather than duplicating API calls.
+
+## Service Dependencies
+
+Use `ConceptDetailService` for concept retrieval and `ConfigurationService` for terminology context when a lookup depends on the selected terminology.
+
+## State and URL Handling
+
+Keep route-derived state aligned with parent concept workflows. Avoid creating separate terminology selection behavior here.
+
+## Entry Points
+
+- `concept-detail.component.ts`
+- `concept-detail.component.html`
+- `concept-detail.component.spec.ts`

--- a/frontend/src/app/component/concept-display/AGENTS.md
+++ b/frontend/src/app/component/concept-display/AGENTS.md
@@ -1,0 +1,23 @@
+# Concept Display Component Context
+
+## Scope
+
+This component owns the full concept details page and the table/export logic derived from a loaded concept.
+
+## User Flow
+
+The component reads terminology/code route state, loads concept summary data, opens hierarchy views, optionally opens the term suggestion form with a concept code, filters selected sources, and builds display/export tables.
+
+## Service Dependencies
+
+Primary dependencies are `ConceptDetailService` for concept and hierarchy data and `ConfigurationService` for terminology, source, and hierarchy-popup state.
+
+## State and URL Handling
+
+Route parameters drive concept lookup. Selected sources are encoded through query parameters for concept and hierarchy links. Keep source filtering consistent with `getSelectedSourcesQueryParam()` and `keepSource()`.
+
+## Entry Points
+
+- `concept-display.component.ts`
+- `concept-display.component.html`
+- `concept-display.component.spec.ts`

--- a/frontend/src/app/component/documentation/AGENTS.md
+++ b/frontend/src/app/component/documentation/AGENTS.md
@@ -1,0 +1,27 @@
+# Documentation Components Context
+
+## Scope
+
+This directory contains metadata documentation pages for EVS terminologies.
+
+## Metadata Documentation Pattern
+
+Documentation components generally resolve the current terminology from routing/configuration state, call `ConfigurationService` metadata endpoints, and render the response as reference tables or static overview content.
+
+## Terminology Route Parameters
+
+Most documentation routes support `:terminology` and default redirects from route names without a terminology segment. Keep route behavior centralized in `app-routing.module.ts`.
+
+## Core Components
+
+- `associations`
+- `properties`
+- `qualifiers`
+- `roles`
+- `sources`
+- `term-types`
+- `definition-types`
+- `synonym-types`
+- `overview`
+- `alldocs`
+- `subset-ncit`

--- a/frontend/src/app/component/general-search/AGENTS.md
+++ b/frontend/src/app/component/general-search/AGENTS.md
@@ -1,0 +1,23 @@
+# General Search Component Context
+
+## Scope
+
+This component owns the main search screen, including single-term search, multi-term search, facets, paging, selected columns, and search export behavior.
+
+## User Flow
+
+The component initializes configuration from route/query parameters, prepares search criteria, runs search requests, updates the URL query string, lazy-loads table pages, and exports selected display columns.
+
+## Service Dependencies
+
+Primary dependencies are `SearchTermService` for search/export requests and `ConfigurationService` for terminology, source, metadata, and multi-search state.
+
+## State and URL Handling
+
+Search state is represented by `SearchCriteria` plus component fields for selected sources, terminology, paging, table columns, and multi-term input. Keep URL query parameters synchronized through the existing component methods rather than adding parallel state.
+
+## Entry Points
+
+- `general-search.component.ts`
+- `general-search.component.html`
+- `general-search.component.spec.ts`

--- a/frontend/src/app/component/hierarchy-display/AGENTS.md
+++ b/frontend/src/app/component/hierarchy-display/AGENTS.md
@@ -1,0 +1,23 @@
+# Hierarchy Display Component Context
+
+## Scope
+
+This component owns the full hierarchy browser for concept tree paths and child expansion.
+
+## User Flow
+
+The component loads hierarchy paths for a selected concept, pages through multiple hierarchy positions, expands/collapses tree nodes, loads child nodes on demand, scrolls to the selected tree row, and filters display by selected sources.
+
+## Service Dependencies
+
+Primary dependencies are `ConceptDetailService` for hierarchy data and `ConfigurationService` for terminology/source state and popup triggers.
+
+## State and URL Handling
+
+Route parameters provide terminology and concept code. Query parameters can carry selected source filters. Keep hierarchy and concept links consistent with existing `hierarchyPart`, `conceptPart`, and URL target fields.
+
+## Entry Points
+
+- `hierarchy-display.component.ts`
+- `hierarchy-display.component.html`
+- `hierarchy-display.component.spec.ts`

--- a/frontend/src/app/component/hierarchy-popup/AGENTS.md
+++ b/frontend/src/app/component/hierarchy-popup/AGENTS.md
@@ -1,0 +1,23 @@
+# Hierarchy Popup Component Context
+
+## Scope
+
+This component owns the popup-oriented hierarchy browser variant.
+
+## User Flow
+
+The component mirrors the hierarchy tree loading and source-filter behavior used by the full hierarchy display while adapting close behavior, route naming, and target handling for popup use.
+
+## Service Dependencies
+
+Use `ConceptDetailService` for hierarchy data and `ConfigurationService` for terminology, source, and popup status state.
+
+## State and URL Handling
+
+Keep popup route handling aligned with the route table and the full hierarchy component. Avoid changing popup close behavior without checking how `ConfigurationService` popup flags are used by concept pages.
+
+## Entry Points
+
+- `hierarchy-popup.component.ts`
+- `hierarchy-popup.component.html`
+- `hierarchy-popup.component.spec.ts`

--- a/frontend/src/app/component/mapping-details/AGENTS.md
+++ b/frontend/src/app/component/mapping-details/AGENTS.md
@@ -1,0 +1,23 @@
+# Mapping Details Component Context
+
+## Scope
+
+This component owns mapset detail and mapping row display.
+
+## User Flow
+
+The component reads the mapset code from the route, loads mapset details and mapping rows, handles paging/search/sort behavior, and renders map relationships for users.
+
+## Service Dependencies
+
+Use `MapsetService` for mapset and mapping retrieval. Keep shared terminology metadata behavior in `ConfigurationService` if needed.
+
+## State and URL Handling
+
+Route parameter `:code` identifies the mapset. Keep paging and filter state coordinated with the service request parameters.
+
+## Entry Points
+
+- `mapping-details.component.ts`
+- `mapping-details.component.html`
+- `mapping-details.component.spec.ts`

--- a/frontend/src/app/component/mappings/AGENTS.md
+++ b/frontend/src/app/component/mappings/AGENTS.md
@@ -1,0 +1,23 @@
+# Mappings Component Context
+
+## Scope
+
+This component owns the mapset listing workflow.
+
+## User Flow
+
+The component loads available mapsets, renders list/table state, and links users to mapping detail pages.
+
+## Service Dependencies
+
+Use `MapsetService` for mapset retrieval. Use `ConfigurationService` only when terminology or source context is required by the existing workflow.
+
+## State and URL Handling
+
+Keep links aligned with `/mappings` and `/mappings/:code` routes from `app-routing.module.ts`.
+
+## Entry Points
+
+- `mappings.component.ts`
+- `mappings.component.html`
+- `mappings.component.spec.ts`

--- a/frontend/src/app/component/subset-details/AGENTS.md
+++ b/frontend/src/app/component/subset-details/AGENTS.md
@@ -1,0 +1,23 @@
+# Subset Details Component Context
+
+## Scope
+
+This component owns subset member detail pages, including lazy loading, sorting, searching, CDISC-specific display helpers, and export formatting.
+
+## User Flow
+
+The component loads subset metadata and member rows, responds to table lazy-load events, searches within subset members, and formats export rows using concept properties and synonyms.
+
+## Service Dependencies
+
+Use `ConceptDetailService` for subset info, members, and export retrieval. Use `ConfigurationService` for terminology context and export limits.
+
+## State and URL Handling
+
+Route parameters identify the subset terminology and code. Keep paging, sort, and search state in the component table workflow so exports match the visible query.
+
+## Entry Points
+
+- `subset-details.component.ts`
+- `subset-details.component.html`
+- `subset-details.component.spec.ts`

--- a/frontend/src/app/component/subsets/AGENTS.md
+++ b/frontend/src/app/component/subsets/AGENTS.md
@@ -1,0 +1,23 @@
+# Subsets Component Context
+
+## Scope
+
+This component owns the subset hierarchy browser.
+
+## User Flow
+
+The component loads top-level subset hierarchy data, expands/collapses tree nodes, reveals more children, supports subset tree search, and sorts NCIt-related nodes for display.
+
+## Service Dependencies
+
+Use `ConceptDetailService` for subset hierarchy retrieval and `ConfigurationService` for terminology context.
+
+## State and URL Handling
+
+The selected terminology comes from route/configuration state. Keep subset detail links consistent with `/subset/:terminology/:code` routing.
+
+## Entry Points
+
+- `subsets.component.ts`
+- `subsets.component.html`
+- `subsets.component.spec.ts`

--- a/frontend/src/app/component/term-suggestion-form/AGENTS.md
+++ b/frontend/src/app/component/term-suggestion-form/AGENTS.md
@@ -1,0 +1,23 @@
+# Term Suggestion Form Component Context
+
+## Scope
+
+This component owns the dynamic term suggestion form workflow, including form sections, validators, captcha state, loaded form display, and submission behavior.
+
+## User Flow
+
+The component builds reactive form controls from field/section definitions, validates required and length-constrained inputs, supports clearing/reset behavior, handles captcha success/expiry, and sends form data through the form service.
+
+## Service Dependencies
+
+Use `TermSuggestionFormService` for form submission and related API calls. Use Angular reactive forms for validation rather than manual DOM validation.
+
+## State and URL Handling
+
+Concept code or context can be passed from concept workflows. Keep incoming context handling compatible with links from `ConceptDisplayComponent`.
+
+## Entry Points
+
+- `term-suggestion-form.component.ts`
+- `term-suggestion-form.component.html`
+- `term-suggestion-form.component.spec.ts`

--- a/frontend/src/app/directive/AGENTS.md
+++ b/frontend/src/app/directive/AGENTS.md
@@ -1,0 +1,14 @@
+# Directive Context
+
+## Scope
+
+This directory owns custom Angular directives.
+
+## DOM Interaction Pattern
+
+Directives may interact with the DOM when Angular templates need reusable behavior that does not belong in a component. Keep direct DOM behavior minimal and covered by directive tests.
+
+## Entry Points
+
+- `autofocus/autofocus.directive.ts`
+- `autofocus/autofocus.directive.spec.ts`

--- a/frontend/src/app/model/AGENTS.md
+++ b/frontend/src/app/model/AGENTS.md
@@ -1,0 +1,30 @@
+# Model Context
+
+## Scope
+
+This directory owns TypeScript model classes, interfaces, and enums used to represent EVS API responses and UI display state.
+
+## API Response Wrappers
+
+Several models accept raw API objects in constructors and normalize fields for component display. Keep transformation logic here when it is reusable display-domain logic, especially for concepts, relationships, definitions, synonyms, history, and maps.
+
+## Search and Table Models
+
+Search and table state are represented by models such as `SearchCriteria`, `SearchResult`, `SearchResultTableFormat`, `Facet`, `FacetField`, `TableData`, and `TableHeader`.
+
+## Concept Formatting Logic
+
+`concept.ts` owns rich concept display helpers for preferred names, highlights, definitions, synonyms, relationships, maps, CDISC subset behavior, and text summaries. Avoid duplicating those helpers in components.
+
+## Core Models
+
+- `concept.ts`
+- `searchCriteria.ts`
+- `searchResult.ts`
+- `searchResultTableFormat.ts`
+- `relationship.ts`
+- `definition.ts`
+- `synonym.ts`
+- `map.ts`
+- `history.ts`
+- `termFormData.model.ts`

--- a/frontend/src/app/service/AGENTS.md
+++ b/frontend/src/app/service/AGENTS.md
@@ -1,0 +1,31 @@
+# Service Context
+
+## Scope
+
+This directory owns Angular services, interceptors, shared data subjects, notification handling, error handling, and one shared display pipe.
+
+## API Access Pattern
+
+Services call relative `/api/v1/**` URLs. During Angular development those requests are proxied by `proxy.config.json` or `proxy.dev.config.json`; in packaged deployments the Java web module proxies them to EVSRESTAPI.
+
+## Configuration State
+
+`ConfigurationService` is the central owner of selected terminology, source filters, metadata, export sizes, term documentation flags, hierarchy popup flags, and startup configuration loading. Do not duplicate this state in other services.
+
+## Error and Loading Flow
+
+API services wrap failures in `EvsError` where appropriate. `GlobalErrorHandler`, `NotificationService`, `LoaderService`, and `LoadingInterceptor` coordinate app-level feedback and loading state.
+
+## Core Services
+
+- `configuration.service.ts`
+- `concept-detail.service.ts`
+- `search-term.service.ts`
+- `mapset.service.ts`
+- `term-suggestion-form.service.ts`
+- `loading-interceptor.service.ts`
+- `global-error-handler.service.ts`
+- `loader.service.ts`
+- `notification.service.ts`
+- `common-data.service.ts`
+- `display.pipe.ts`

--- a/frontend/src/assets/AGENTS.md
+++ b/frontend/src/assets/AGENTS.md
@@ -1,0 +1,17 @@
+# Asset Context
+
+## Scope
+
+This directory contains source assets copied by Angular builds.
+
+## Image Assets
+
+Images under `images/` support EVS tiles, screenshots, logos, header assets, and footer assets. Prefer updating source assets here instead of editing copied files under `web/src/main/resources/static/assets`.
+
+## Download Assets
+
+Files under `downloads/` are shipped as user-downloadable assets by the Angular build.
+
+## Custom PrimeNG CSS
+
+`primeng.custom.css` contains application-specific PrimeNG styling overrides loaded globally through `angular.json`.

--- a/frontend/src/environments/AGENTS.md
+++ b/frontend/src/environments/AGENTS.md
@@ -1,0 +1,17 @@
+# Environment Context
+
+## Scope
+
+This directory owns Angular environment constants and production file replacement behavior.
+
+## Development Environment
+
+`environment.ts` is used for local development. It sets `production: false`, local host expectations, the development Google Analytics code, and the dev Swagger URL.
+
+## Production Environment
+
+`environment.prod.ts` is substituted by Angular production builds. It sets `production: true`, production host expectations, the production Google Analytics code, and the production Swagger URL.
+
+## Analytics and Swagger URLs
+
+`AppComponent` reads environment analytics values for Google Analytics setup. API documentation links should use the environment Swagger value rather than hard-coded component URLs.

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -1,0 +1,25 @@
+# Web Module Context
+
+## Scope
+
+This module owns the Spring Boot web application, Java backend proxy behavior, WAR packaging, runtime configuration, and static hosting of the built Angular app.
+
+## Module Architecture
+
+The module is a Java 17 Spring Boot application using Gradle. It disables JDBC datasource auto-configuration, binds EVS Explore web properties from `application.yml`, serves static Angular assets from `src/main/resources/static`, and forwards API calls to EVSRESTAPI through Java request handling.
+
+## Build and Runtime Notes
+
+- `build.gradle` defines Spring Boot, Spring Cloud Gateway MVC dependencies, dependency locking, WAR packaging, and zip packaging.
+- `src/main/resources/application.yml` defines the servlet context path, server port, logging levels, and `gov.nih.nci.evsexplore.web` property namespace.
+- `src/main/resources/static` is build output copied from `frontend/dist`; do not treat hashed JS/CSS files there as source files.
+- `src/main/bin/evsexplore` is packaged into the distribution zip as an executable helper script.
+
+## Configuration and Resources
+
+Runtime values are environment-backed through `application.yml`, including server port, context path, EVS API base path, UI license, and logging levels. Logging is configured by `src/main/resources/logback.xml`.
+
+## Context Map
+
+- [src/main/java/gov/nih/nci/evsexplore/web/AGENTS.md](src/main/java/gov/nih/nci/evsexplore/web/AGENTS.md): Java application package and child package map.
+- [src/test/java/gov/nih/nci/evsexplore/web/AGENTS.md](src/test/java/gov/nih/nci/evsexplore/web/AGENTS.md): Java test package and child package map.

--- a/web/src/main/java/gov/nih/nci/evsexplore/web/AGENTS.md
+++ b/web/src/main/java/gov/nih/nci/evsexplore/web/AGENTS.md
@@ -1,0 +1,29 @@
+# Java Web Application Context
+
+## Scope
+
+This package is the root Java package for the EVS Explore Spring Boot web application.
+
+## Application Entry Point
+
+`EVSWebApplication.java` bootstraps Spring Boot, excludes datasource auto-configuration, enables `WebProperties`, and starts the application.
+
+## Spring Composition
+
+Spring components are organized by concern:
+
+- `controllers`: request handling and EVSRESTAPI proxying.
+- `configuration`: static resources and SPA route forwarding.
+- `filters`: servlet request mutation before controller handling.
+- `properties`: configuration binding for EVS Explore web settings.
+
+## Package Map
+
+- [controllers/AGENTS.md](controllers/AGENTS.md): proxy controller and service behavior.
+- [configuration/AGENTS.md](configuration/AGENTS.md): static asset handlers and route forwarding.
+- [filters/AGENTS.md](filters/AGENTS.md): license-header request filter behavior.
+- [properties/AGENTS.md](properties/AGENTS.md): bound web properties and their consumers.
+
+## Core Files
+
+- `EVSWebApplication.java`

--- a/web/src/main/java/gov/nih/nci/evsexplore/web/configuration/AGENTS.md
+++ b/web/src/main/java/gov/nih/nci/evsexplore/web/configuration/AGENTS.md
@@ -1,0 +1,21 @@
+# Configuration Context
+
+## Scope
+
+This package owns Spring MVC configuration for static resource delivery and browser-route fallback.
+
+## Static Resource Handling
+
+`StaticResourcesConfiguration` registers explicit handlers for common static file extensions and serves them from Spring Boot's default static locations with a short cache duration.
+
+## SPA Route Forwarding
+
+Client-side Angular routes are forwarded to `index.html` when they do not represent static files or API routes. The explicit `/concept/**` forwarding exists because concept routes may contain dots.
+
+## Cache Behavior
+
+Static resources are served with a 30-second max-age cache control. Keep cache changes coordinated with Angular hashed build assets and deployment expectations.
+
+## Entry Points
+
+- `StaticResourcesConfiguration.java`

--- a/web/src/main/java/gov/nih/nci/evsexplore/web/controllers/AGENTS.md
+++ b/web/src/main/java/gov/nih/nci/evsexplore/web/controllers/AGENTS.md
@@ -1,0 +1,26 @@
+# Controllers Context
+
+## Scope
+
+This package owns inbound API proxy handling for requests under `api/v1/**`.
+
+## Request Flow
+
+`EVSController` receives matching requests and delegates to `ProxyService`. `ProxyService` builds the EVSRESTAPI URI from `WebProperties.evsApibasePath`, the servlet path, and the original query string.
+
+## Proxy Pattern
+
+The proxy preserves request body, HTTP method, and incoming headers while removing hop-by-hop size/transfer headers that can cause downstream gateway problems. It uses a new `RestTemplate` with a buffering request factory for each proxied request.
+
+## Header and Body Handling
+
+`content-length` and `transfer-encoding` are intentionally skipped when copying headers. Responses are returned with fresh `HttpHeaders` to avoid gateway errors in deployed environments.
+
+## Error Handling
+
+`HttpStatusCodeException` from the downstream API is converted into a response with the downstream status and body. Unexpected controller-level exceptions are logged and rethrown.
+
+## Entry Points
+
+- `EVSController.java`
+- `ProxyService.java`

--- a/web/src/main/java/gov/nih/nci/evsexplore/web/filters/AGENTS.md
+++ b/web/src/main/java/gov/nih/nci/evsexplore/web/filters/AGENTS.md
@@ -1,0 +1,21 @@
+# Filters Context
+
+## Scope
+
+This package owns servlet filters that run before MVC controller handling.
+
+## Request Mutation Pattern
+
+`UiHeaderPreFilter` wraps the incoming `HttpServletRequest` in a mutable request wrapper so application code can add a synthetic header while retaining original request headers.
+
+## License Header Injection
+
+The filter injects `X-EVSRESTAPI-License-Key` with the configured UI license from `WebProperties`. This happens at highest precedence so the proxied request includes the license header before controller forwarding.
+
+## Servlet Filter Ordering
+
+The filter is annotated with `@Order(Ordered.HIGHEST_PRECEDENCE)`. Keep any additional filters explicit about ordering when they affect proxied headers or request visibility.
+
+## Entry Points
+
+- `UiHeaderPreFilter.java`

--- a/web/src/main/java/gov/nih/nci/evsexplore/web/properties/AGENTS.md
+++ b/web/src/main/java/gov/nih/nci/evsexplore/web/properties/AGENTS.md
@@ -1,0 +1,24 @@
+# Properties Context
+
+## Scope
+
+This package owns configuration binding classes for the Java web module.
+
+## Configuration Binding
+
+`WebProperties` binds values from the `gov.nih.nci.evsexplore.web` prefix in `application.yml`. The class is enabled from the application entry point.
+
+## Environment-Backed Properties
+
+`application.yml` maps these properties to environment variables with defaults:
+
+- `evsApibasePath`: defaults to local EVSRESTAPI.
+- `uiLicense`: defaults to `ui-license`.
+
+## Consumers
+
+`ProxyService` uses the EVS API base path to build downstream request URIs. `UiHeaderPreFilter` uses the UI license to inject the EVSRESTAPI license header.
+
+## Entry Points
+
+- `WebProperties.java`

--- a/web/src/test/java/gov/nih/nci/evsexplore/web/AGENTS.md
+++ b/web/src/test/java/gov/nih/nci/evsexplore/web/AGENTS.md
@@ -1,0 +1,17 @@
+# Java Test Context
+
+## Scope
+
+This package contains Java tests for the Spring Boot web module.
+
+## Test Frameworks
+
+Tests use JUnit 5, Mockito, and AssertJ through `spring-boot-starter-test`.
+
+## Test Layout
+
+Mirror production package names under `web/src/test/java`. Keep tests close to the Spring concern being verified, and prefer focused unit tests for MVC configuration, filters, and proxy behavior unless a full Spring context is needed.
+
+## Context Map
+
+- [configuration/AGENTS.md](configuration/AGENTS.md): tests for static resource and SPA route configuration.

--- a/web/src/test/java/gov/nih/nci/evsexplore/web/configuration/AGENTS.md
+++ b/web/src/test/java/gov/nih/nci/evsexplore/web/configuration/AGENTS.md
@@ -1,0 +1,17 @@
+# Configuration Tests Context
+
+## Scope
+
+This package tests Java static resource and SPA fallback configuration.
+
+## Mocking Strategy
+
+`StaticResourcesConfigurationTest` uses Mockito mocks for Spring MVC registry and registration objects. Keep these tests focused on verifying registered handlers, resource locations, cache setup, resource chains, and view-controller mappings.
+
+## Behavior Under Test
+
+The test verifies static resource extension registration, default static resource locations, cache-control registration, resource-chain enablement, and Angular route forwarding to `index.html`.
+
+## Core Test Files
+
+- `StaticResourcesConfigurationTest.java`


### PR DESCRIPTION
Summary:
- Add hierarchical AGENTS.md context files for root, Java web, frontend, tests, assets, and Cypress.
- Keep parent context files map-oriented while child directories own implementation details.
- Document key entry points and local patterns for Spring Boot and Angular areas.

Tests: Not run (documentation-only changes).