### PR TITLE
Pva/evsrestapi 730 make fhir more visible

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -69,7 +69,15 @@
                 }
               ]
             },
-            "development": {}
+            "development": {},
+            "dev": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.dev.ts"
+                }
+              ]
+            }
           },
           "defaultConfiguration": "production"
         },
@@ -82,6 +90,9 @@
             },
             "development": {
               "buildTarget": "frontend:build:development"
+            },
+            "dev": {
+              "buildTarget": "frontend:build:dev"
             }
           },
           "defaultConfiguration": "development"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve --proxy-config proxy.config.json",
-    "start:dev": "ng serve --proxy-config proxy.dev.config.json",
+    "start:dev": "ng serve --configuration dev --proxy-config proxy.dev.config.json",
     "build": "ng build",
     "build:prod": "ng build --configuration production --base-href /evsexplore/ ",
     "test": "jest",

--- a/frontend/src/app/api-documentation-url.spec.ts
+++ b/frontend/src/app/api-documentation-url.spec.ts
@@ -1,0 +1,25 @@
+import { getApiDocumentationOrigin, getFhirSwaggerUrl, getSwaggerUrl } from './api-documentation-url';
+import { environment } from '../environments/environment';
+
+describe('API documentation URLs', () => {
+  it.each([
+    ['localhost', 'http:', 'http://localhost:8082/swagger-ui/index.html'],
+    ['evsexplore-dev.semantics.cancer.gov', 'https:', 'https://api-evsrest-dev.semantics.cancer.gov/swagger-ui/index.html'],
+    ['evsexplore-qa.semantics.cancer.gov', 'https:', 'https://api-evsrest-qa.semantics.cancer.gov/swagger-ui/index.html'],
+    ['evsexplore-stage.semantics.cancer.gov', 'https:', 'https://api-evsrest-stage.semantics.cancer.gov/swagger-ui/index.html'],
+    ['evsexplore.semantics.cancer.gov', 'https:', 'https://api-evsrest.semantics.cancer.gov/swagger-ui/index.html'],
+  ])('maps %s to its matching API Swagger host', (hostname, protocol, expectedUrl) => {
+    expect(getApiDocumentationOrigin(hostname, protocol)).toBe(new URL(expectedUrl).origin);
+    expect(getSwaggerUrl(hostname, protocol)).toBe(expectedUrl);
+  });
+
+  it('uses the configured Swagger origin for unrecognized hosts', () => {
+    expect(getApiDocumentationOrigin('evsexplore-preview2.semantics.cancer.gov', 'https:'))
+      .toBe(new URL(environment.swagger).origin);
+  });
+
+  it('builds FHIR links from the resolved API origin', () => {
+    expect(getFhirSwaggerUrl('r4')).toBe('http://localhost:8082/fhir/r4/swagger-ui/');
+    expect(getFhirSwaggerUrl('r5')).toBe('http://localhost:8082/fhir/r5/swagger-ui/');
+  });
+});

--- a/frontend/src/app/api-documentation-url.spec.ts
+++ b/frontend/src/app/api-documentation-url.spec.ts
@@ -3,22 +3,22 @@ import { environment } from '../environments/environment';
 
 describe('API documentation URLs', () => {
   it.each([
-    ['localhost', 'http:', 'http://localhost:8082/swagger-ui/index.html'],
-    ['evsexplore-dev.semantics.cancer.gov', 'https:', 'https://api-evsrest-dev.semantics.cancer.gov/swagger-ui/index.html'],
-    ['evsexplore-qa.semantics.cancer.gov', 'https:', 'https://api-evsrest-qa.semantics.cancer.gov/swagger-ui/index.html'],
-    ['evsexplore-stage.semantics.cancer.gov', 'https:', 'https://api-evsrest-stage.semantics.cancer.gov/swagger-ui/index.html'],
-    ['evsexplore.semantics.cancer.gov', 'https:', 'https://api-evsrest.semantics.cancer.gov/swagger-ui/index.html'],
-  ])('maps %s to its matching API documentation endpoints', (hostname, protocol, expectedSwaggerUrl) => {
+    ['localhost', 'http://localhost:8082/swagger-ui/index.html'],
+    ['evsexplore-dev.semantics.cancer.gov', 'https://api-evsrest-dev.nci.nih.gov/swagger-ui/index.html'],
+    ['evsexplore-qa.semantics.cancer.gov', 'https://api-evsrest-qa.nci.nih.gov/swagger-ui/index.html'],
+    ['evsexplore-stage.semantics.cancer.gov', 'https://api-evsrest-stage.nci.nih.gov/swagger-ui/index.html'],
+    ['evsexplore.semantics.cancer.gov', 'https://api-evsrest.nci.nih.gov/swagger-ui/index.html'],
+  ])('maps %s to its matching API documentation endpoints', (hostname, expectedSwaggerUrl) => {
     const apiOrigin = new URL(expectedSwaggerUrl).origin;
 
-    expect(getApiDocumentationOrigin(hostname, protocol)).toBe(apiOrigin);
-    expect(getSwaggerUrl(hostname, protocol)).toBe(expectedSwaggerUrl);
-    expect(getFhirSwaggerUrl('r4', hostname, protocol)).toBe(`${apiOrigin}/fhir/r4/swagger-ui/`);
-    expect(getFhirSwaggerUrl('r5', hostname, protocol)).toBe(`${apiOrigin}/fhir/r5/swagger-ui/`);
+    expect(getApiDocumentationOrigin(hostname)).toBe(apiOrigin);
+    expect(getSwaggerUrl(hostname)).toBe(expectedSwaggerUrl);
+    expect(getFhirSwaggerUrl('r4', hostname)).toBe(`${apiOrigin}/fhir/r4/swagger-ui/`);
+    expect(getFhirSwaggerUrl('r5', hostname)).toBe(`${apiOrigin}/fhir/r5/swagger-ui/`);
   });
 
   it('uses the configured Swagger origin for unrecognized hosts', () => {
-    expect(getApiDocumentationOrigin('evsexplore-preview2.semantics.cancer.gov', 'https:'))
+    expect(getApiDocumentationOrigin('evsexplore-preview2.semantics.cancer.gov'))
       .toBe(new URL(environment.swagger).origin);
   });
 });

--- a/frontend/src/app/api-documentation-url.spec.ts
+++ b/frontend/src/app/api-documentation-url.spec.ts
@@ -8,18 +8,17 @@ describe('API documentation URLs', () => {
     ['evsexplore-qa.semantics.cancer.gov', 'https:', 'https://api-evsrest-qa.semantics.cancer.gov/swagger-ui/index.html'],
     ['evsexplore-stage.semantics.cancer.gov', 'https:', 'https://api-evsrest-stage.semantics.cancer.gov/swagger-ui/index.html'],
     ['evsexplore.semantics.cancer.gov', 'https:', 'https://api-evsrest.semantics.cancer.gov/swagger-ui/index.html'],
-  ])('maps %s to its matching API Swagger host', (hostname, protocol, expectedUrl) => {
-    expect(getApiDocumentationOrigin(hostname, protocol)).toBe(new URL(expectedUrl).origin);
-    expect(getSwaggerUrl(hostname, protocol)).toBe(expectedUrl);
+  ])('maps %s to its matching API documentation endpoints', (hostname, protocol, expectedSwaggerUrl) => {
+    const apiOrigin = new URL(expectedSwaggerUrl).origin;
+
+    expect(getApiDocumentationOrigin(hostname, protocol)).toBe(apiOrigin);
+    expect(getSwaggerUrl(hostname, protocol)).toBe(expectedSwaggerUrl);
+    expect(getFhirSwaggerUrl('r4', hostname, protocol)).toBe(`${apiOrigin}/fhir/r4/swagger-ui/`);
+    expect(getFhirSwaggerUrl('r5', hostname, protocol)).toBe(`${apiOrigin}/fhir/r5/swagger-ui/`);
   });
 
   it('uses the configured Swagger origin for unrecognized hosts', () => {
     expect(getApiDocumentationOrigin('evsexplore-preview2.semantics.cancer.gov', 'https:'))
       .toBe(new URL(environment.swagger).origin);
-  });
-
-  it('builds FHIR links from the resolved API origin', () => {
-    expect(getFhirSwaggerUrl('r4')).toBe('http://localhost:8082/fhir/r4/swagger-ui/');
-    expect(getFhirSwaggerUrl('r5')).toBe('http://localhost:8082/fhir/r5/swagger-ui/');
   });
 });

--- a/frontend/src/app/api-documentation-url.ts
+++ b/frontend/src/app/api-documentation-url.ts
@@ -25,6 +25,10 @@ export function getSwaggerUrl(
   return `${getApiDocumentationOrigin(hostname, protocol)}/swagger-ui/index.html`;
 }
 
-export function getFhirSwaggerUrl(version: 'r4' | 'r5'): string {
-  return `${getApiDocumentationOrigin()}/fhir/${version}/swagger-ui/`;
+export function getFhirSwaggerUrl(
+  version: 'r4' | 'r5',
+  hostname = window.location.hostname,
+  protocol = window.location.protocol
+): string {
+  return `${getApiDocumentationOrigin(hostname, protocol)}/fhir/${version}/swagger-ui/`;
 }

--- a/frontend/src/app/api-documentation-url.ts
+++ b/frontend/src/app/api-documentation-url.ts
@@ -1,34 +1,20 @@
 import { environment } from '../environments/environment';
 
-const localHosts = new Set(['localhost', '127.0.0.1', '::1']);
+const apiDocumentationOrigins: Record<string, string> = {
+  'evsexplore.semantics.cancer.gov': 'https://api-evsrest.nci.nih.gov',
+  'evsexplore-dev.semantics.cancer.gov': 'https://api-evsrest-dev.nci.nih.gov',
+  'evsexplore-qa.semantics.cancer.gov': 'https://api-evsrest-qa.nci.nih.gov',
+  'evsexplore-stage.semantics.cancer.gov': 'https://api-evsrest-stage.nci.nih.gov',
+};
 
-export function getApiDocumentationOrigin(
-  hostname = window.location.hostname,
-  protocol = window.location.protocol
-): string {
-  if (localHosts.has(hostname)) {
-    return new URL(environment.swagger).origin;
-  }
-
-  if (/^evsexplore(?:-(?:dev|qa|stage))?(?:\.|$)/.test(hostname)) {
-    const apiHostname = hostname.replace(/^evsexplore/, 'api-evsrest');
-    return `${protocol}//${apiHostname}`;
-  }
-
-  return new URL(environment.swagger).origin;
+export function getApiDocumentationOrigin(hostname = window.location.hostname): string {
+  return apiDocumentationOrigins[hostname] ?? new URL(environment.swagger).origin;
 }
 
-export function getSwaggerUrl(
-  hostname = window.location.hostname,
-  protocol = window.location.protocol
-): string {
-  return `${getApiDocumentationOrigin(hostname, protocol)}/swagger-ui/index.html`;
+export function getSwaggerUrl(hostname = window.location.hostname): string {
+  return `${getApiDocumentationOrigin(hostname)}/swagger-ui/index.html`;
 }
 
-export function getFhirSwaggerUrl(
-  version: 'r4' | 'r5',
-  hostname = window.location.hostname,
-  protocol = window.location.protocol
-): string {
-  return `${getApiDocumentationOrigin(hostname, protocol)}/fhir/${version}/swagger-ui/`;
+export function getFhirSwaggerUrl(version: 'r4' | 'r5', hostname = window.location.hostname): string {
+  return `${getApiDocumentationOrigin(hostname)}/fhir/${version}/swagger-ui/`;
 }

--- a/frontend/src/app/api-documentation-url.ts
+++ b/frontend/src/app/api-documentation-url.ts
@@ -1,0 +1,30 @@
+import { environment } from '../environments/environment';
+
+const localHosts = new Set(['localhost', '127.0.0.1', '::1']);
+
+export function getApiDocumentationOrigin(
+  hostname = window.location.hostname,
+  protocol = window.location.protocol
+): string {
+  if (localHosts.has(hostname)) {
+    return new URL(environment.swagger).origin;
+  }
+
+  if (/^evsexplore(?:-(?:dev|qa|stage))?(?:\.|$)/.test(hostname)) {
+    const apiHostname = hostname.replace(/^evsexplore/, 'api-evsrest');
+    return `${protocol}//${apiHostname}`;
+  }
+
+  return new URL(environment.swagger).origin;
+}
+
+export function getSwaggerUrl(
+  hostname = window.location.hostname,
+  protocol = window.location.protocol
+): string {
+  return `${getApiDocumentationOrigin(hostname, protocol)}/swagger-ui/index.html`;
+}
+
+export function getFhirSwaggerUrl(version: 'r4' | 'r5'): string {
+  return `${getApiDocumentationOrigin()}/fhir/${version}/swagger-ui/`;
+}

--- a/frontend/src/app/component/evs-api/evs-api.component.ts
+++ b/frontend/src/app/component/evs-api/evs-api.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { DomSanitizer, Title } from '@angular/platform-browser';
-import { environment } from '../../../environments/environment';
+import { getSwaggerUrl } from '../../api-documentation-url';
 
 @Component({
   selector: 'app-evs-api',
@@ -15,7 +15,7 @@ export class EvsApiComponent implements OnInit {
 
   ngOnInit(): void {
     this.titleService.setTitle('EVS Explore API');
-    this.apiUrl = this.sanitizer.bypassSecurityTrustResourceUrl(environment.swagger);
+    this.apiUrl = this.sanitizer.bypassSecurityTrustResourceUrl(getSwaggerUrl());
   }
 
 }

--- a/frontend/src/app/component/welcome/welcome.component.html
+++ b/frontend/src/app/component/welcome/welcome.component.html
@@ -193,8 +193,11 @@
               <td width="3px;"></td>
               <td class="textbody" valign="top">
                 <a [routerLink]="['/evsapi']" alt="Swagger API Documentation" class="regular-link"> Swagger API
-                  Documentation</a>: View
-                documentation for the EVS REST API providing data to this application.
+                  Documentation</a>: View documentation for the EVS REST API providing data to this application. See
+                also <a [href]="fhirR4SwaggerUrl" target="_blank"
+                        rel="noopener noreferrer" class="regular-link">FHIR R4 APIs</a> and
+                <a [href]="fhirR5SwaggerUrl" target="_blank"
+                   rel="noopener noreferrer" class="regular-link">FHIR R5 APIs</a>.
               </td>
             </tr>
             <tr valign="top">

--- a/frontend/src/app/component/welcome/welcome.component.spec.ts
+++ b/frontend/src/app/component/welcome/welcome.component.spec.ts
@@ -36,4 +36,5 @@ describe('WelcomeComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
 });

--- a/frontend/src/app/component/welcome/welcome.component.ts
+++ b/frontend/src/app/component/welcome/welcome.component.ts
@@ -5,6 +5,7 @@ import { DomSanitizer, Title } from '@angular/platform-browser';
 import { ConfigurationService } from '../../service/configuration.service';
 import { ActivatedRoute } from '@angular/router';
 import { AppComponent } from '../../app.component';
+import { getFhirSwaggerUrl } from '../../api-documentation-url';
 
 // Welcome screen component (simple component wrapper around welcome.component.html)
 @Component({
@@ -15,6 +16,9 @@ import { AppComponent } from '../../app.component';
 })
 export class WelcomeComponent implements OnInit, OnDestroy, AfterViewInit {
   @ViewChild('content', { static: true }) content: TemplateRef<any>;
+
+  readonly fhirR4SwaggerUrl = getFhirSwaggerUrl('r4');
+  readonly fhirR5SwaggerUrl = getFhirSwaggerUrl('r5');
 
   welcomeText: any = null;
   boilerPlateWelcomeText: any = 'Loading welcome text for ' + this.configService.getTerminologyName() + ' ...';

--- a/frontend/src/environments/AGENTS.md
+++ b/frontend/src/environments/AGENTS.md
@@ -4,9 +4,13 @@
 
 This directory owns Angular environment constants and production file replacement behavior.
 
-## Development Environment
+## Local Environment
 
-`environment.ts` is used for local development. It sets `production: false`, local host expectations, the development Google Analytics code, and the dev Swagger URL.
+`environment.ts` is used for ordinary local development. It sets `production: false`, local host expectations, the development Google Analytics code, and the local EVSRESTAPI Swagger URL.
+
+## Dev-Proxy Environment
+
+`environment.dev.ts` is used by `npm run start:dev`. It keeps the Angular app on localhost while directing Swagger and FHIR documentation links to NCI dev EVSRESTAPI, matching `proxy.dev.config.json`.
 
 ## Production Environment
 

--- a/frontend/src/environments/environment.dev.ts
+++ b/frontend/src/environments/environment.dev.ts
@@ -1,0 +1,7 @@
+// This file is used by `npm run start:dev`, which proxies application API requests to NCI dev EVSRESTAPI.
+export const environment = {
+  production: false,
+  host: 'localhost',
+  code: 'G-C8Y98QQ6LR',
+  swagger: 'https://api-evsrest-dev.nci.nih.gov/swagger-ui/index.html',
+};

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -6,7 +6,7 @@ export const environment = {
   production: false,
   host: 'localhost',
   code: 'G-C8Y98QQ6LR',
-  swagger: 'https://api-evsrest-dev.nci.nih.gov/swagger-ui/index.html',
+  swagger: 'http://localhost:8082/swagger-ui/index.html',
 };
 
 /*


### PR DESCRIPTION
Adds links to the front page of EVS-Explore directly to the swagger UI pages. Also a few miscellaneous fixes such as a 500 error on the R5 page, and some disconnects in dev linking to dev, qa to qa, etc.